### PR TITLE
Correction on Page 91

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ The following errata have been reported that apply to the print version of the b
 - p.32: `Out[15]` should read '3' instead of 'int_arr[3]'.
 - p.32: `Out[22]` should read `array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0])` instead of `array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])`.
 - p.72: `In [6]` should read `ridgereg = linear_model.Ridge()` instead of `ridgereg = linear_model.RidgeRegression()`.
+- p.91:  The last paragraph should read `We also specify an empty array, np.array([]), for the mean argument, which tells OpenCV to  compute the mean from the data:` instead of `We also specify an empty array, np.array([]), for the mask argument, which tells OpenCV to use all data points in the feature matrix:`.
 - p.120: `In [16]` should read `dtree = cv2.ml.DTrees_create()` instead of `dtree = cv2.ml.dtree_create()`.
 - p.122: `In [26]` should read `with open("tree.dot", 'w'): f = tree.export_graphviz(dtc, out_file=f, feature_names=vec.get_feature_names(), class_names=['A', 'B', 'C', 'D'])` instead of `with open("tree.dot", 'w'): f = tree.export_graphviz(clf, out_file=f)`.
 - p.147: The first occurrences of `X_hypo = np.c_[xx.ravel().astype(np.float32), yy.ravel().astype(np.float32)]` and `_, zz = svm.predict(X_hypo)` should be removed, as they mistakenly appear twice.


### PR DESCRIPTION
In the section on cv2.PCACompute, the book states that the second argument is for a data array mask but I couldn't use it. According to the docs this argument should be used to provide mean values not an array mask. I'm not that familiar with numpy or opencv but I think this is in error.

OpenCV 2 Python Documentation for cv2.PCACompute:
https://docs.opencv.org/2.4.13/modules/core/doc/operations_on_arrays.html?highlight=cv2.pcacompute#cv2.PCACompute

OpenCV 3 Documentation for cv::PCA::operator () used by cv2.PCACompute:
https://docs.opencv.org/3.1.0/d3/d8d/classcv_1_1PCA.html#a26e76331a68988144a403649c6b8af5c
